### PR TITLE
Update GitHub action workflow

### DIFF
--- a/.github/workflows/create_dev_release.yml
+++ b/.github/workflows/create_dev_release.yml
@@ -12,12 +12,38 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Build and push Docker images
-        uses: docker/build-push-action@v1
+      
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
         with:
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          repository: holores/suisei-mic/discord-bot-dev
-          registry: docker.pkg.github.com
-          tags: latest
-          tag_with_sha: true
+          images: ghcr.io/${{ github.repository }}-dev
+          tag-sha: true
+          tag-custom: 'latest'
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-  
+
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -8,15 +8,40 @@ jobs:
   deploy:
     runs-on: ubuntu-20.04
     if: "!contains(github.event.head_commit.message, 'ci skip:')" # If the commit contains "ci skip" this action won't run
-    steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Build and push Docker images
-        uses: docker/build-push-action@v1
+
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
         with:
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          repository: holores/suisei-mic/discord-bot
-          registry: docker.pkg.github.com
-          tags: latest
-          tag_with_sha: true
+          images: ghcr.io/${{ github.repository }}
+          tag-sha: true
+          tag-custom: 'latest'
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-  
+
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -8,6 +8,7 @@ jobs:
   deploy:
     runs-on: ubuntu-20.04
     if: "!contains(github.event.head_commit.message, 'ci skip:')" # If the commit contains "ci skip" this action won't run
+    steps:
       - name: Checkout code
         uses: actions/checkout@v2
 


### PR DESCRIPTION
Closes #25 
Migrate from **GitHub Registry for Docker images** to **GitHub Packages**
Update to [docker/build-push-action@v2](https://github.com/docker/build-push-action) and leverage GitHub cache.